### PR TITLE
Add order state and live activity

### DIFF
--- a/Appetizers/Model/Order.swift
+++ b/Appetizers/Model/Order.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+final class Order: ObservableObject {
+    @Published var items: [Appetizer] = []
+
+    func add(_ appetizer: Appetizer) {
+        items.append(appetizer)
+    }
+
+    func removeItems(at offsets: IndexSet) {
+        items.remove(atOffsets: offsets)
+    }
+
+    var totalPrice: Double {
+        items.reduce(0) { $0 + $1.price }
+    }
+}

--- a/Appetizers/Screens/AppetizerListView/AppetizerListView.swift
+++ b/Appetizers/Screens/AppetizerListView/AppetizerListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 struct AppetizerListView: View {
     @StateObject var viewModel = AppetizerListViewVM()
+    @EnvironmentObject var order: Order
 
     // ← add this to hold whichever row was tapped
 
@@ -30,8 +31,9 @@ struct AppetizerListView: View {
             .blur(radius:  viewModel.isShowingDetail ? 20 : 0)
 
             if  viewModel.isShowingDetail{
-            
+
                 OrderDetailsView(appetizer: viewModel.selectedAppetizer!, isShowingDetail: $viewModel.isShowingDetail)
+                    .environmentObject(order)
 
             }
 
@@ -54,5 +56,6 @@ struct AppetizerListView: View {
 struct AppetizerListView_Previews: PreviewProvider {
     static var previews: some View {
         AppetizerListView()
+            .environmentObject(Order())
     }
 }

--- a/Appetizers/Screens/AppetizerTabView.swift
+++ b/Appetizers/Screens/AppetizerTabView.swift
@@ -8,9 +8,12 @@
 import SwiftUI
 
 struct AppetizerTabView: View {
+    @StateObject var order = Order()
+
     var body: some View {
         TabView{
             AppetizerListView()
+                .environmentObject(order)
                 .tabItem {
                     Image(systemName: "house")
                     Text("Home")
@@ -21,6 +24,7 @@ struct AppetizerTabView: View {
                     Text("Account")
                 }
             OrderView()
+                .environmentObject(order)
                 .tabItem {
                     Image(systemName: "bag")
                     Text("Order")

--- a/Appetizers/Screens/DetailsView/OrderDetailsView.swift
+++ b/Appetizers/Screens/DetailsView/OrderDetailsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct OrderDetailsView: View {
     let appetizer: Appetizer
     @Binding var isShowingDetail: Bool
+    @EnvironmentObject var order: Order
 
 
     var body: some View {
@@ -38,8 +39,9 @@ struct OrderDetailsView: View {
             } 
             
             Spacer()
-                    
-            FinalPriceButton(price: appetizer.price)
+
+            FinalPriceButton(appetizer: appetizer)
+                .environmentObject(order)
 
                 }
                 .frame(width: 300, height: 525)
@@ -61,6 +63,7 @@ struct OrderDetailsView: View {
 struct OrderDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         OrderDetailsView(appetizer: MOCKDATA.sampleAppetizer, isShowingDetail: .constant(true))
+            .environmentObject(Order())
     }
 }
 

--- a/Appetizers/Screens/OrderView/OrderView.swift
+++ b/Appetizers/Screens/OrderView/OrderView.swift
@@ -8,15 +8,13 @@
 import SwiftUI
 
 struct OrderView: View {
-    @State private var orderItems: [Appetizer] = MOCKDATA.appetizers
-
-    var appetizer = MOCKDATA.sampleAppetizer
+    @EnvironmentObject var order: Order
     var body: some View {
         NavigationView{
             VStack{
                 List{
-                
-                    ForEach(orderItems){ appetizer in
+
+                    ForEach(order.items){ appetizer in
                         AppetizerListCell(appetizer: appetizer)
                     }.onDelete(perform: deleteItems)
                     
@@ -24,11 +22,11 @@ struct OrderView: View {
                     .listStyle(PlainListStyle())
                 Spacer()
                 Button{
-                    
+                    DeliveryActivityManager.start()
                 } label: {
 
                     // with two-decimal formatting
-                    ApButton(title: "\(appetizer.price, specifier: "%.2f") - Place Order")
+                    ApButton(title: "\(order.totalPrice, specifier: "%.2f") - Place Order")
 
                 }
 
@@ -39,7 +37,7 @@ struct OrderView: View {
         }
     }
     func deleteItems(at offsets: IndexSet){
-        orderItems.remove(atOffsets: offsets)
+        order.removeItems(at: offsets)
     }
 
 }
@@ -47,4 +45,5 @@ struct OrderView: View {
 
 #Preview {
     OrderView()
+        .environmentObject(Order())
 }

--- a/Appetizers/Utilities/Managers/DeliveryActivityManager.swift
+++ b/Appetizers/Utilities/Managers/DeliveryActivityManager.swift
@@ -1,0 +1,23 @@
+import ActivityKit
+import Foundation
+
+struct DeliveryAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var timeRemaining: Int
+    }
+}
+
+enum DeliveryActivityManager {
+    static func start() {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let attributes = DeliveryAttributes()
+        let state = DeliveryAttributes.ContentState(timeRemaining: 15 * 60)
+        do {
+            _ = try Activity<DeliveryAttributes>.request(attributes: attributes,
+                                                         contentState: state,
+                                                         pushType: nil)
+        } catch {
+            print("Unable to start activity: \(error)")
+        }
+    }
+}

--- a/Appetizers/Views/Buttons/FinalPriceButton.swift
+++ b/Appetizers/Views/Buttons/FinalPriceButton.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 struct FinalPriceButton : View {
-    
-    let price: Double
-    
+
+    let appetizer: Appetizer
+    @EnvironmentObject var order: Order
+
     var body: some View {
         Button {
-            // add to order action
-            print("tapped")
+            order.add(appetizer)
         } label: {
-            ApButton(title: "$\(price, specifier: "%.2f") - Add to Order")
+            ApButton(title: "$\(appetizer.price, specifier: "%.2f") - Add to Order")
         }
         .padding(.bottom, 30)
     }
@@ -24,5 +24,6 @@ struct FinalPriceButton : View {
 
 
 #Preview {
-    FinalPriceButton(price: 5.99)
+    FinalPriceButton(appetizer: MOCKDATA.sampleAppetizer)
+        .environmentObject(Order())
 }


### PR DESCRIPTION
## Summary
- add a shared `Order` model for keeping selected appetizers
- update the tab view and all related screens to use the shared order
- implement `FinalPriceButton` to add items to the order
- show a 15‑minute delivery live activity when placing an order

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_6846a3632bb883259f7dbc55b8158e8f